### PR TITLE
Add CMake install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ TARGET_LINK_LIBRARIES(wave_geometry INTERFACE Eigen3::Eigen ${BOOST_LIBRARIES})
 TARGET_INCLUDE_DIRECTORIES(wave_geometry INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-INSTALL(TARGETS wave_geometry EXPORT wave_geometryConfig)
+# Install to include path set by GNUInstallDirs
+INSTALL(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # We ship the headers of Tick and always want to use this exact version
 # Add Tick header to the include path as well.
@@ -84,9 +85,12 @@ TARGET_INCLUDE_DIRECTORIES(wave_geometry INTERFACE
   $<INSTALL_INTERFACE:3rd-party/Tick>)
 INSTALL(DIRECTORY 3rd-party DESTINATION .)
 
-# Install to include path set by GNUInstallDirs
-INSTALL(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
+# Generate the Config file for the install tree
+SET(WAVE_GEOMETRY_EXTRA_CMAKE_DIR "cmake")
+CONFIGURE_PACKAGE_CONFIG_FILE(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/wave_geometryConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wave_geometryConfig.cmake"
+  INSTALL_DESTINATION "${INSTALL_CMAKE_DIR}")
 
 # Generate the Version file
 WRITE_BASIC_PACKAGE_VERSION_FILE(wave_geometryConfigVersion.cmake
@@ -98,10 +102,20 @@ SET(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_DATADIR}/wave_geometry/cmake" CACHE PATH
   "Installation directory for CMake files")
 
 # Install the Config and ConfigVersion files
-INSTALL(EXPORT wave_geometryConfig DESTINATION "${INSTALL_CMAKE_DIR}")
 INSTALL(FILES
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wave_geometryConfig.cmake"
   "${PROJECT_BINARY_DIR}/wave_geometryConfigVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}")
+# Install auto-generated targets file used by the Config file
+INSTALL(TARGETS wave_geometry EXPORT wave_geometryTargets)
+INSTALL(EXPORT wave_geometryTargets DESTINATION "${INSTALL_CMAKE_DIR}")
+
+# Install our import scripts so we can use them in the Config script. That way,
+# other projects using wave_geometry will get transient dependencies (such as
+# Eigen) automatically
+INSTALL(DIRECTORY "${WAVE_GEOMETRY_EXTRA_CMAKE_DIR}/"
+  DESTINATION "${INSTALL_CMAKE_DIR}/${WAVE_GEOMETRY_EXTRA_CMAKE_DIR}"
+  FILES_MATCHING PATTERN "Add*.cmake" PATTERN "Find*.cmake")
 
 IF(EXPORT_BUILD)
   # Export this build so the package can be found through CMake's registry

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,6 @@ INSTALL(FILES
 # Install auto-generated targets file used by the Config file
 INSTALL(TARGETS wave_geometry EXPORT wave_geometryTargets)
 INSTALL(EXPORT wave_geometryTargets DESTINATION "${INSTALL_CMAKE_DIR}")
-
 # Install our import scripts so we can use them in the Config script. That way,
 # other projects using wave_geometry will get transient dependencies (such as
 # Eigen) automatically
@@ -121,4 +120,24 @@ IF(EXPORT_BUILD)
   # Export this build so the package can be found through CMake's registry
   # without being installed.
   EXPORT(PACKAGE wave_geometry)
+
+  # Create a Targets file in the build directory
+  EXPORT(EXPORT wave_geometryTargets FILE wave_geometryTargets.cmake)
+
+  # Generate the Config file for the build tree
+  # It differs from the installed Config file in where our bundled
+  # Import*.cmake scripts are included from. Here, use the relative path from
+  # the build directory to this source directory
+  FILE(RELATIVE_PATH path_to_wave_geometry_source
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR})
+  SET(WAVE_GEOMETRY_EXTRA_CMAKE_DIR "${path_to_wave_geometry_source}cmake")
+  CONFIGURE_PACKAGE_CONFIG_FILE(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/wave_geometryConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/wave_geometryConfig.cmake"
+    INSTALL_DESTINATION "${INSTALL_CMAKE_DIR}")
+
+  message(STATUS "Exporting to the CMake user package registry. The command "
+          "FIND_PACKAGE(wave_geometry) can now find this directory, without "
+          "installing.")
 ENDIF(EXPORT_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,22 @@ PROJECT(wave_geometry)
 # Compiler settings for all targets
 SET(CMAKE_CXX_STANDARD 11)
 
+# Package version, used when other projects FIND_PACKAGE(wave <version>)
+SET(WAVE_GEOMETRY_PACKAGE_VERSION 0.2.0)
+
 # CMake modules
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 INCLUDE(CMakePackageConfigHelpers)
+INCLUDE(GNUInstallDirs)
 INCLUDE(cmake/WaveGeometryHelpers.cmake)
 INCLUDE(cmake/AddEigen3.cmake)
 ENABLE_TESTING()
 
 # User options
 OPTION(BUILD_TESTING "Build tests" ON)
+OPTION(EXPORT_BUILD
+  "Add this build directory to CMake's user package registry.\
+ Allows the package to be found without install." OFF)
 OPTION(BUILD_BENCHMARKS
   "Build benchmarks for some components. Requires google benchmark package."
   OFF)
@@ -56,13 +63,48 @@ ENDIF(BUILD_BENCHMARKS)
 # We use header-only parts of boost: boost::optional
 FIND_PACKAGE(Boost REQUIRED)
 
-# We ship the headers of Tick. Make it an imported target.
-ADD_LIBRARY(Tick::Tick INTERFACE IMPORTED)
-SET_PROPERTY(TARGET Tick::Tick PROPERTY
-  INTERFACE_INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/3rd-party/Tick")
-
 # Make a target for wave_geometry
 ADD_LIBRARY(wave_geometry INTERFACE)
 TARGET_COMPILE_OPTIONS(wave_geometry INTERFACE -Wall -Wextra)
-TARGET_LINK_LIBRARIES(wave_geometry INTERFACE Eigen3::Eigen Tick::Tick ${BOOST_LIBRARIES})
-TARGET_INCLUDE_DIRECTORIES(wave_geometry INTERFACE include/)
+TARGET_LINK_LIBRARIES(wave_geometry INTERFACE Eigen3::Eigen ${BOOST_LIBRARIES})
+
+# Set the public include paths so they are usable from both the build and
+# install tree. See:
+# https://cmake.org/cmake/help/v3.4/manual/cmake-buildsystem.7.html#include-directories-and-usage-requirements
+# https://stackoverflow.com/a/25681179
+TARGET_INCLUDE_DIRECTORIES(wave_geometry INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+INSTALL(TARGETS wave_geometry EXPORT wave_geometryConfig)
+
+# We ship the headers of Tick and always want to use this exact version
+# Add Tick header to the include path as well.
+TARGET_INCLUDE_DIRECTORIES(wave_geometry INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/Tick>
+  $<INSTALL_INTERFACE:3rd-party/Tick>)
+INSTALL(DIRECTORY 3rd-party DESTINATION .)
+
+# Install to include path set by GNUInstallDirs
+INSTALL(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+
+# Generate the Version file
+WRITE_BASIC_PACKAGE_VERSION_FILE(wave_geometryConfigVersion.cmake
+  VERSION ${WAVE_GEOMETRY_PACKAGE_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+# This is where .cmake files will be installed (default under share/)
+SET(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_DATADIR}/wave_geometry/cmake" CACHE PATH
+  "Installation directory for CMake files")
+
+# Install the Config and ConfigVersion files
+INSTALL(EXPORT wave_geometryConfig DESTINATION "${INSTALL_CMAKE_DIR}")
+INSTALL(FILES
+  "${PROJECT_BINARY_DIR}/wave_geometryConfigVersion.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}")
+
+IF(EXPORT_BUILD)
+  # Export this build so the package can be found through CMake's registry
+  # without being installed.
+  EXPORT(PACKAGE wave_geometry)
+ENDIF(EXPORT_BUILD)

--- a/README.md
+++ b/README.md
@@ -135,13 +135,42 @@ Quaternions use the conventions of `Eigen::Quaternion`: Hamilton product, storag
 
 ## How to install
 
-`wave_geometry` is a header-only library, meaning no compilation is required to use it in your project. Put the `include` directory into your compiler's search path, and write
+`wave_geometry` is a header-only library, meaning no compilation is required to use it in your project.
 
+`wave_geometry` can be installed with cmake.
+
+```bash
+mkdir build
+cd build
+cmake .. -DBUILD_TESTING=OFF
+sudo make install
 ```
+
+Setting the `BUILD_TESTING` option to `ON` (the default) will build unit tests,
+and `make test` will run them.
+
+As an alternative to `make install`, the CMake option `-DEXPORT_BUILD=ON` will
+make the build directory findable by other CMake projects without installation.
+
+## How to use in your CMake project
+
+Once libwave has been either installed or exported by CMake, it can be used in
+your project's `CMakeLists.txt` file as follows:
+
+```cmake
+cmake_minimum_required(VERSION 3.2)
+project(example)
+
+find_package(wave_geometry REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(example wave_geometry)
+```
+
+In your C++ file, write:
+```cpp
 #include <wave/geometry/geometry.hpp>
 ```
-
-CMake install and link commands will be added soon.
 
 ### Dependencies
 

--- a/cmake/wave_geometryConfig.cmake.in
+++ b/cmake/wave_geometryConfig.cmake.in
@@ -1,0 +1,89 @@
+# wave_geometry - a manifold geometry library for robotics
+# Copyright (c) 2018 Leo Koppel (Waterloo Autonomous Vehicles Lab)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Config file for wave package: find wave_geometry and its dependencies
+#
+# This script exports a target called wave_geometry.
+# Note this install is curently separate from that of libwave, which has
+# modules such as wave::utils.
+#
+# For example, to link "my_target" against wave_geometry and its dependencies,
+# call:
+#     find_package(wave_geometry REQUIRED)
+#     target_link_libaries(my_target wave_geometry)
+#
+# Note that this command is sufficient to add all required libraries, include
+# directories, and other compile flags to the target.
+#
+# This file defines the following variables:
+#
+# wave_geometry_FOUND: True if wave_geometry and required dependencies were
+#             successfully found. WAVE_GEOMETRY_FOUND is also set.
+#
+# WAVE_GEOMETRY_VERSION: The version number found
+
+@PACKAGE_INIT@
+
+# Prints a failure message and exits, setting WAVE_FOUND=FALSE
+# Arguments are printed at the end of the message.
+MACRO(WAVE_FAIL)
+    # Check variables set by find_package() depending on its QUIET and REQUIRED
+    # options, and print a different type of message accordingly
+    IF(wave_geometry_FIND_REQUIRED)
+        MESSAGE(FATAL_ERROR "Failed to find wave_geometry: " ${ARGN})
+    ELSEIF(NOT wave_FIND_QUIETLY)
+        MESSAGE(WARNING "Failed to find wave_geometry: " ${ARGN})
+    ENDIF()
+
+    # Tell FIND_PACKAGE that this package should be considered "not found"
+    SET(wave_FOUND FALSE)
+    # Set this all-caps version only as a courtesy to users, who may be
+    # mistakenly (but understandably) expecting this convention
+    SET(WAVE_FOUND FALSE)
+    RETURN()
+ENDMACRO(WAVE_FAIL)
+
+
+SET(WAVE_GEOMETRY_VERSION @WAVE_GEOMETRY_PACKAGE_VERSION@)
+SET_AND_CHECK(WAVE_GEOMETRY_EXTRA_CMAKE_DIR
+    "${CMAKE_CURRENT_LIST_DIR}/@WAVE_GEOMETRY_EXTRA_CMAKE_DIR@")
+
+# Find dependencies used by wave_geometry, and where dependencies do not provide
+# imported targets, define them.
+LIST(APPEND CMAKE_MODULE_PATH "${WAVE_GEOMETRY_EXTRA_CMAKE_DIR}")
+# Currently the only dependency is Eigen.
+INCLUDE(${WAVE_GEOMETRY_EXTRA_CMAKE_DIR}/AddEigen3.cmake)
+
+# Include auto-generated targets file
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/wave_geometryTargets.cmake")
+
+# Check that for each component in waveTargets (even non-requested ones), its
+# dependencies are found. If not, print a warning in non-quiet mode (since they
+# must have been there at build time, something is up).
+GET_TARGET_PROPERTY(wave_geometry_deps wave_geometry INTERFACE_LINK_LIBRARIES)
+MESSAGE(STATUS "wave_geometry dependencies: ${wave_geometry_deps}")
+
+# wave_geometry_FOUND, with exact case, is the variable set and used by
+# FIND_PACKAGE(). Setting it here is redundant, but is done for clarity. The
+# second variable is provided only as a courtesy to users who may expect
+# all-caps names.
+SET(wave_geometry_FOUND TRUE)
+SET(WAVE_GEOMETRY_FOUND TRUE)


### PR DESCRIPTION
Install cmake config files to allow FIND_PACKAGE(wave_geometry).

The config file finds Eigen as a transient dependency. Adapted from my CMake code for libwave.

Remove imported target Tick::Tick; just treat it as part of wave_geometry's include directories for now.

Add EXPORT_BUILD option.

Add install instructions to ReadMe.