### PR TITLE
Add scalar multiplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The code is available under the [MIT License](LICENSE).
 | Sum | <img src="https://latex.codecogs.com/png.latex?\mathbf{v}&plus;\mathbf{v}" title="\mathbf{v}+\mathbf{v}" /> | `v + v` |
 | Difference | <img src="https://latex.codecogs.com/png.latex?\mathbf{v}-\mathbf{v}" title="\mathbf{v}-\mathbf{v}" /> | `v - v` |
 | Negative  | <img src="https://latex.codecogs.com/png.latex?-\mathbf&space;v" title="-\mathbf v" /> | `-v` |
+| Scalar multiplication   | <img src="https://latex.codecogs.com/png.latex?a\mathbf&space;v" title="a\mathbf v" /> | `a * v` |
+| Scalar division   | <img src="https://latex.codecogs.com/png.latex?\mathbf&space;v/a" title="\mathbf v/a" /> | `v / a` |
 | Composition | <img src="https://latex.codecogs.com/png.latex?\mathbf&space;\Phi&space;\circ&space;\mathbf&space;\Phi" title="\mathbf \Phi \circ \mathbf \Phi" /> | `R * R` |
 | Inverse | <img src="https://latex.codecogs.com/png.latex?\mathbf&space;\Phi^{-1}" title="\mathbf \Phi^{-1}" /> | `inverse(R)` |
 | Coordinate map | <img src="https://latex.codecogs.com/png.latex?\mathbf&space;\Phi&space;(\mathbf&space;p)" title="\mathbf \Phi (\mathbf p)" /> | `R * p` |
@@ -32,7 +34,10 @@ The code is available under the [MIT License](LICENSE).
 | Manifold plus | <img src="https://latex.codecogs.com/png.latex?\mathbf\Phi\boxplus\mathbf\varphi=\exp(\mathbf\varphi)\circ\mathbf\Phi" title="\mathbf\Phi \boxplus \mathbf\varphi = \exp(\mathbf\varphi) \circ \mathbf\Phi" /> | `R + w` |
 | Manifold minus | <img src="https://latex.codecogs.com/png.latex?\mathbf\Phi_1\boxminus\mathbf\Phi_2=\log(\mathbf\Phi_1\circ\mathbf\Phi_2^{-1})" title="\mathbf\Phi_1 \boxminus \mathbf\Phi_2 = \log(\mathbf\Phi_1 \circ \mathbf\Phi_2^{-1})" /> | `R - R` |
 
-Above, <img src="https://latex.codecogs.com/png.latex?\mathbf\Phi" alt="Phi" /> or `R` represents a Lie group element, <img src="https://latex.codecogs.com/png.latex?\mathbf\varphi" alt="small phi" />  or `w` represents a Lie algebra element, <img src="https://latex.codecogs.com/png.latex?\mathbf{p}" alt="p" /> or `p` represents a translation, and <img src="https://latex.codecogs.com/png.latex?\mathbf{v}" alt="v" /> or `v` represents any element of R^3, so(3) or se(3).
+Above, <img src="https://latex.codecogs.com/png.latex?\mathbf\Phi" alt="Phi" /> or `R` represents a Lie group element, <img src="https://latex.codecogs.com/png.latex?\mathbf\varphi" alt="small phi" />  or `w` represents a Lie algebra element,
+<img src="https://latex.codecogs.com/png.latex?\mathbf{p}" alt="p" /> or `p` represents a translation,
+<img src="https://latex.codecogs.com/png.latex?a" alt="a" /> or `a` represents a scalar,
+and <img src="https://latex.codecogs.com/png.latex?\mathbf{v}" alt="v" /> or `v` represents any element of R^n, so(3) or se(3).
 
 ### Automatic differentiation
 

--- a/include/wave/geometry/geometry.hpp
+++ b/include/wave/geometry/geometry.hpp
@@ -51,6 +51,7 @@
 #include "src/geometry/op/BoxMinus.hpp"
 #include "src/geometry/op/Minus.hpp"
 #include "src/geometry/op/Scale.hpp"
+#include "src/geometry/op/Product.hpp"
 #include "src/geometry/op/Inverse.hpp"
 
 #endif  // WAVE_GEOMETRY_GEOMETRY_HPP

--- a/include/wave/geometry/geometry.hpp
+++ b/include/wave/geometry/geometry.hpp
@@ -52,6 +52,7 @@
 #include "src/geometry/op/Minus.hpp"
 #include "src/geometry/op/Scale.hpp"
 #include "src/geometry/op/Product.hpp"
+#include "src/geometry/op/Divide.hpp"
 #include "src/geometry/op/Inverse.hpp"
 
 #endif  // WAVE_GEOMETRY_GEOMETRY_HPP

--- a/include/wave/geometry/geometry.hpp
+++ b/include/wave/geometry/geometry.hpp
@@ -50,6 +50,7 @@
 #include "src/geometry/op/BoxPlus.hpp"
 #include "src/geometry/op/BoxMinus.hpp"
 #include "src/geometry/op/Minus.hpp"
+#include "src/geometry/op/Scale.hpp"
 #include "src/geometry/op/Inverse.hpp"
 
 #endif  // WAVE_GEOMETRY_GEOMETRY_HPP

--- a/include/wave/geometry/src/geometry/base/ScalarBase.hpp
+++ b/include/wave/geometry/src/geometry/base/ScalarBase.hpp
@@ -91,10 +91,19 @@ auto wrapInputScalar(const T &&arg) -> Scalar<T> {
     return Scalar<T>{std::move(arg)};
 }
 
+/** Trivial implementation of scalar * scalar product
+ * Defer to the implementation type's arithmetic operators.
+ */
+template <typename Lhs, typename Rhs>
+auto evalImpl(expr<Product>, const ScalarBase<Lhs> &lhs, const ScalarBase<Rhs> &rhs)
+  -> decltype(makeScalarResult(lhs.derived().value() * rhs.derived().value())) {
+    return makeScalarResult(lhs.derived().value() * rhs.derived().value());
+}
+
 /** Left Jacobian implementation for scalar * scalar product
  * (return 1x1 matrix) */
 template <typename Res, typename Lhs, typename Rhs>
-auto leftJacobianImpl(expr<Scale>,
+auto leftJacobianImpl(expr<Product>,
                       const Res &,
                       const ScalarBase<Lhs> &,
                       const ScalarBase<Rhs> &rhs) -> jacobian_t<Res, Lhs> {
@@ -103,7 +112,7 @@ auto leftJacobianImpl(expr<Scale>,
 /** Right Jacobian implementation for scalar * scalar product
  * (return 1x1 matrix) */
 template <typename Res, typename Lhs, typename Rhs>
-auto rightJacobianImpl(expr<Scale>,
+auto rightJacobianImpl(expr<Product>,
                        const Res &,
                        const ScalarBase<Lhs> &lhs,
                        const ScalarBase<Rhs> &) -> jacobian_t<Res, Rhs> {
@@ -130,13 +139,13 @@ WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(-, ScalarBase)
  * @f[ \mathbb{R}^n \times \mathbb{R} \to \mathbb{R}^n @f]
  */
 template <typename L, typename R>
-auto operator*(const ScalarBase<L> &lhs, const ScalarBase<R> &rhs) -> Scale<L, R> {
-    return Scale<L, R>{lhs.derived(), rhs.derived()};
+auto operator*(const ScalarBase<L> &lhs, const ScalarBase<R> &rhs) -> Product<L, R> {
+    return Product<L, R>{lhs.derived(), rhs.derived()};
 }
 
-WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(*, ScalarBase)
+WAVE_OVERLOAD_FUNCTION_FOR_RVALUES(operator*, Product, ScalarBase, ScalarBase)
 
-WAVE_OVERLOAD_FUNCTION_FOR_RVALUES(operator*, Scale, ScalarBase, ScalarBase)
+WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(*, ScalarBase)
 
 }  // namespace wave
 

--- a/include/wave/geometry/src/geometry/base/ScalarBase.hpp
+++ b/include/wave/geometry/src/geometry/base/ScalarBase.hpp
@@ -161,6 +161,17 @@ auto operator-(ScalarBase<L> &&lhs, R &&rhs)
     return std::move(lhs).derived() - internal::wrapInputScalar(std::forward<R>(rhs));
 }
 
+/** Multiplication of two scalar expressions
+ *
+ * @f[ \mathbb{R}^n \times \mathbb{R} \to \mathbb{R}^n @f]
+ */
+template <typename L, typename R>
+auto operator*(const ScalarBase<L> &lhs, const ScalarBase<R> &rhs) -> Scale<L, R> {
+    return Scale<L, R>{lhs.derived(), rhs.derived()};
+}
+
+WAVE_OVERLOAD_FUNCTION_FOR_RVALUES(operator*, Scale, ScalarBase, ScalarBase)
+
 }  // namespace wave
 
 #endif  // WAVE_GEOMETRY_SCALARBASE_HPP

--- a/include/wave/geometry/src/geometry/base/ScalarBase.hpp
+++ b/include/wave/geometry/src/geometry/base/ScalarBase.hpp
@@ -97,69 +97,14 @@ auto wrapInputScalar(const T &&arg) -> Scalar<T> {
  *
  * @f[ \mathbb{R} \times \mathbb{R} \to \mathbb{R} @f]
  */
-template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<L>{})>
-auto operator+(L &&lhs, const ScalarBase<R> &rhs)
-  -> decltype(internal::wrapInputScalar(std::forward<L>(lhs)) + rhs.derived()) {
-    return internal::wrapInputScalar(std::forward<L>(lhs)) + rhs.derived();
-}
-// Overload for rvalue
-template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<L>{})>
-auto operator+(L &&lhs, ScalarBase<R> &&rhs)
-  -> decltype(internal::wrapInputScalar(std::forward<L>(lhs)) +
-              std::move(rhs).derived()) {
-    return internal::wrapInputScalar(std::forward<L>(lhs)) + std::move(rhs).derived();
-}
+WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(+, ScalarBase)
 
-/** Adds a scalar expression and a plain scalar
- *
- * @f[ \mathbb{R} \times \mathbb{R} \to \mathbb{R} @f]
- */
-template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<R>{})>
-auto operator+(const ScalarBase<L> &lhs, R &&rhs)
-  -> decltype(lhs.derived() + internal::wrapInputScalar(std::forward<R>(rhs))) {
-    return lhs.derived() + internal::wrapInputScalar(std::forward<R>(rhs));
-}
-// Overload for rvalue
-template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<R>{})>
-auto operator+(ScalarBase<L> &&lhs, R &&rhs)
-  -> decltype(std::move(lhs).derived() +
-              internal::wrapInputScalar(std::forward<R>(rhs))) {
-    return std::move(lhs).derived() + internal::wrapInputScalar(std::forward<R>(rhs));
-}
 
 /** Subtracts a plain scalar and a scalar expression
  *
  * @f[ \mathbb{R} \times \mathbb{R} \to \mathbb{R} @f]
  */
-template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<L>{})>
-auto operator-(L &&lhs, const ScalarBase<R> &rhs)
-  -> decltype(internal::wrapInputScalar(std::forward<L>(lhs)) - rhs.derived()) {
-    return internal::wrapInputScalar(std::forward<L>(lhs)) - rhs.derived();
-}
-// Overload for rvalue
-template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<L>{})>
-auto operator-(L &&lhs, ScalarBase<R> &&rhs)
-  -> decltype(internal::wrapInputScalar(std::forward<L>(lhs)) -
-              std::move(rhs).derived()) {
-    return internal::wrapInputScalar(std::forward<L>(lhs)) - std::move(rhs).derived();
-}
-
-/** Subtracts a scalar expression and a plain scalar
- *
- * @f[ \mathbb{R} \times \mathbb{R} \to \mathbb{R} @f]
- */
-template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<R>{})>
-auto operator-(const ScalarBase<L> &lhs, R &&rhs)
-  -> decltype(lhs.derived() - internal::wrapInputScalar(std::forward<R>(rhs))) {
-    return lhs.derived() - internal::wrapInputScalar(std::forward<R>(rhs));
-}
-// Overload for rvalue
-template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<R>{})>
-auto operator-(ScalarBase<L> &&lhs, R &&rhs)
-  -> decltype(std::move(lhs).derived() -
-              internal::wrapInputScalar(std::forward<R>(rhs))) {
-    return std::move(lhs).derived() - internal::wrapInputScalar(std::forward<R>(rhs));
-}
+WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(-, ScalarBase)
 
 /** Multiplication of two scalar expressions
  *

--- a/include/wave/geometry/src/geometry/base/ScalarBase.hpp
+++ b/include/wave/geometry/src/geometry/base/ScalarBase.hpp
@@ -187,7 +187,6 @@ auto operator/(const ScalarBase<L> &lhs, const ScalarBase<R> &rhs) -> Divide<L, 
 WAVE_OVERLOAD_FUNCTION_FOR_RVALUES(operator/, Divide, ScalarBase, ScalarBase)
 WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(/, ScalarBase)
 
-
 }  // namespace wave
 
 #endif  // WAVE_GEOMETRY_SCALARBASE_HPP

--- a/include/wave/geometry/src/geometry/base/ScalarBase.hpp
+++ b/include/wave/geometry/src/geometry/base/ScalarBase.hpp
@@ -91,6 +91,25 @@ auto wrapInputScalar(const T &&arg) -> Scalar<T> {
     return Scalar<T>{std::move(arg)};
 }
 
+/** Left Jacobian implementation for scalar * scalar product
+ * (return 1x1 matrix) */
+template <typename Res, typename Lhs, typename Rhs>
+auto leftJacobianImpl(expr<Scale>,
+                      const Res &,
+                      const ScalarBase<Lhs> &,
+                      const ScalarBase<Rhs> &rhs) -> jacobian_t<Res, Lhs> {
+    return jacobian_t<Res, Lhs>{rhs.derived().value()};
+}
+/** Right Jacobian implementation for scalar * scalar product
+ * (return 1x1 matrix) */
+template <typename Res, typename Lhs, typename Rhs>
+auto rightJacobianImpl(expr<Scale>,
+                       const Res &,
+                       const ScalarBase<Lhs> &lhs,
+                       const ScalarBase<Rhs> &) -> jacobian_t<Res, Rhs> {
+    return jacobian_t<Res, Rhs>{lhs.derived().value()};
+}
+
 }  // namespace internal
 
 /** Adds a plain scalar and a scalar expression
@@ -114,6 +133,8 @@ template <typename L, typename R>
 auto operator*(const ScalarBase<L> &lhs, const ScalarBase<R> &rhs) -> Scale<L, R> {
     return Scale<L, R>{lhs.derived(), rhs.derived()};
 }
+
+WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(*, ScalarBase)
 
 WAVE_OVERLOAD_FUNCTION_FOR_RVALUES(operator*, Scale, ScalarBase, ScalarBase)
 

--- a/include/wave/geometry/src/geometry/base/VectorBase.hpp
+++ b/include/wave/geometry/src/geometry/base/VectorBase.hpp
@@ -287,7 +287,6 @@ auto operator*(const ScalarBase<L> &lhs, const VectorBase<R> &rhs) -> Scale<L, R
     return Scale<L, R>{lhs.derived(), rhs.derived()};
 }
 
-
 WAVE_OVERLOAD_FUNCTION_FOR_RVALUES(operator*, Scale, ScalarBase, VectorBase)
 WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_LEFT(*, VectorBase)
 

--- a/include/wave/geometry/src/geometry/base/VectorBase.hpp
+++ b/include/wave/geometry/src/geometry/base/VectorBase.hpp
@@ -145,9 +145,9 @@ auto evalImpl(expr<Norm>, const VectorBase<Rhs> &rhs)
 
 /** Gradient of L2 norm */
 template <typename Val, typename Rhs>
-auto jacobianImpl(expr<Norm>, const Val &norm, const VectorBase<Rhs> &rhs)
+auto jacobianImpl(expr<Norm>, const ScalarBase<Val> &norm, const VectorBase<Rhs> &rhs)
   -> jacobian_t<Val, Rhs> {
-    return rhs.derived().value() / norm;
+    return rhs.derived().value() / norm.derived().value();
 }
 
 /** Implementation of left scalar multiplication

--- a/include/wave/geometry/src/geometry/forward_declarations.hpp
+++ b/include/wave/geometry/src/geometry/forward_declarations.hpp
@@ -33,6 +33,9 @@ template <typename Lhs, typename Rhs>
 struct ScaleR;
 
 template <typename Lhs, typename Rhs>
+struct ScaleDiv;
+
+template <typename Lhs, typename Rhs>
 struct Product;
 
 template <typename Lhs, typename Rhs>

--- a/include/wave/geometry/src/geometry/forward_declarations.hpp
+++ b/include/wave/geometry/src/geometry/forward_declarations.hpp
@@ -33,6 +33,9 @@ template <typename Lhs, typename Rhs>
 struct ScaleR;
 
 template <typename Lhs, typename Rhs>
+struct Product;
+
+template <typename Lhs, typename Rhs>
 struct Rotate;
 
 template <typename Lhs, typename Rhs>

--- a/include/wave/geometry/src/geometry/forward_declarations.hpp
+++ b/include/wave/geometry/src/geometry/forward_declarations.hpp
@@ -36,6 +36,9 @@ template <typename Lhs, typename Rhs>
 struct Product;
 
 template <typename Lhs, typename Rhs>
+struct Divide;
+
+template <typename Lhs, typename Rhs>
 struct Rotate;
 
 template <typename Lhs, typename Rhs>

--- a/include/wave/geometry/src/geometry/forward_declarations.hpp
+++ b/include/wave/geometry/src/geometry/forward_declarations.hpp
@@ -27,6 +27,12 @@ template <typename Rhs>
 struct Minus;
 
 template <typename Lhs, typename Rhs>
+struct Scale;
+
+template <typename Lhs, typename Rhs>
+struct ScaleR;
+
+template <typename Lhs, typename Rhs>
 struct Rotate;
 
 template <typename Lhs, typename Rhs>

--- a/include/wave/geometry/src/geometry/op/Divide.hpp
+++ b/include/wave/geometry/src/geometry/op/Divide.hpp
@@ -2,18 +2,18 @@
  * @file
  */
 
-#ifndef WAVE_GEOMETRY_PRODUCT_HPP
-#define WAVE_GEOMETRY_PRODUCT_HPP
+#ifndef WAVE_GEOMETRY_DIVIDE_HPP
+#define WAVE_GEOMETRY_DIVIDE_HPP
 
 namespace wave {
 
-/** An expression representing the product of two scalars.
+/** An expression representing scalar / scalar division
  */
 template <typename Lhs, typename Rhs>
-struct Product : internal::base_tmpl_t<Lhs, Rhs, Product<Lhs, Rhs>>,
-                 BinaryExpression<Product<Lhs, Rhs>> {
+struct Divide : internal::base_tmpl_t<Lhs, Rhs, Divide<Lhs, Rhs>>,
+                BinaryExpression<Divide<Lhs, Rhs>> {
     // Inherit constructor from BinaryExpression
-    using BinaryExpression<Product<Lhs, Rhs>>::BinaryExpression;
+    using BinaryExpression<Divide<Lhs, Rhs>>::BinaryExpression;
 };
 
 
@@ -23,7 +23,7 @@ namespace internal {
 // Keep the frames of the vector side.
 // @todo add scalar mixing. Currently the type of Lhs is kept.
 template <typename Lhs, typename Rhs>
-struct traits<Product<Lhs, Rhs>> : binary_traits_base<Product<Lhs, Rhs>> {
+struct traits<Divide<Lhs, Rhs>> : binary_traits_base<Divide<Lhs, Rhs>> {
     using OutputFunctor =
       WrapWithFrames<LeftFrameOf<Lhs>, MiddleFrameOf<Lhs>, RightFrameOf<Lhs>>;
 };
@@ -31,4 +31,4 @@ struct traits<Product<Lhs, Rhs>> : binary_traits_base<Product<Lhs, Rhs>> {
 }  // namespace internal
 }  // namespace wave
 
-#endif  // WAVE_GEOMETRY_PRODUCT_HPP
+#endif  // WAVE_GEOMETRY_DIVIDE_HPP

--- a/include/wave/geometry/src/geometry/op/Product.hpp
+++ b/include/wave/geometry/src/geometry/op/Product.hpp
@@ -1,0 +1,34 @@
+/**
+ * @file
+ */
+
+#ifndef WAVE_GEOMETRY_PRODUCT_HPP
+#define WAVE_GEOMETRY_PRODUCT_HPP
+
+namespace wave {
+
+/** An expression representing the product of two scalars.
+ */
+template <typename Lhs, typename Rhs>
+struct Product : internal::base_tmpl_t<Rhs, Product<Lhs, Rhs>>,
+                 BinaryExpression<Product<Lhs, Rhs>> {
+    // Inherit constructor from BinaryExpression
+    using BinaryExpression<Product<Lhs, Rhs>>::BinaryExpression;
+};
+
+
+namespace internal {
+
+// Traits for left scalar multiplication
+// Keep the frames of the vector side.
+// @todo add scalar mixing. Currently the type of Rhs is kept.
+template <typename Lhs, typename Rhs>
+struct traits<Product<Lhs, Rhs>> : binary_traits_base<Product<Lhs, Rhs>> {
+    using OutputFunctor =
+      WrapWithFrames<LeftFrameOf<Rhs>, MiddleFrameOf<Rhs>, RightFrameOf<Rhs>>;
+};
+
+}  // namespace internal
+}  // namespace wave
+
+#endif  // WAVE_GEOMETRY_PRODUCT_HPP

--- a/include/wave/geometry/src/geometry/op/Scale.hpp
+++ b/include/wave/geometry/src/geometry/op/Scale.hpp
@@ -26,6 +26,17 @@ struct ScaleR : internal::base_tmpl_t<Lhs, ScaleR<Lhs, Rhs>>,
     using BinaryExpression<ScaleR<Lhs, Rhs>>::BinaryExpression;
 };
 
+/** An expression representing the division of a vector (Lhs) by a scalar (Rhs).
+ * Equivalent to right scalar multiplication by the inverse of the scalar.
+ */
+template <typename Lhs, typename Rhs>
+struct ScaleDiv : internal::base_tmpl_t<Lhs, ScaleDiv<Lhs, Rhs>>,
+                  BinaryExpression<ScaleDiv<Lhs, Rhs>> {
+    // Inherit constructor from BinaryExpression
+    using BinaryExpression<ScaleDiv<Lhs, Rhs>>::BinaryExpression;
+};
+
+
 namespace internal {
 
 // Traits for left scalar multiplication
@@ -42,6 +53,15 @@ struct traits<Scale<Lhs, Rhs>> : binary_traits_base<Scale<Lhs, Rhs>> {
 // @todo add scalar mixing. Currently the type of Lhs is kept.
 template <typename Lhs, typename Rhs>
 struct traits<ScaleR<Lhs, Rhs>> : binary_traits_base<ScaleR<Lhs, Rhs>> {
+    using OutputFunctor =
+      WrapWithFrames<LeftFrameOf<Lhs>, MiddleFrameOf<Lhs>, RightFrameOf<Lhs>>;
+};
+
+// Traits for right scalar division
+// Keep the frames of the vector side.
+// @todo add scalar mixing. Currently the type of Lhs is kept.
+template <typename Lhs, typename Rhs>
+struct traits<ScaleDiv<Lhs, Rhs>> : binary_traits_base<ScaleDiv<Lhs, Rhs>> {
     using OutputFunctor =
       WrapWithFrames<LeftFrameOf<Lhs>, MiddleFrameOf<Lhs>, RightFrameOf<Lhs>>;
 };

--- a/include/wave/geometry/src/geometry/op/Scale.hpp
+++ b/include/wave/geometry/src/geometry/op/Scale.hpp
@@ -1,0 +1,52 @@
+/**
+ * @file
+ */
+
+#ifndef WAVE_GEOMETRY_SCALE_HPP
+#define WAVE_GEOMETRY_SCALE_HPP
+
+namespace wave {
+
+/** An expression representing left scalar multiplication of a vector.
+ */
+template <typename Lhs, typename Rhs>
+struct Scale : internal::base_tmpl_t<Rhs, Scale<Lhs, Rhs>>,
+               BinaryExpression<Scale<Lhs, Rhs>> {
+    // Inherit constructor from BinaryExpression
+    using BinaryExpression<Scale<Lhs, Rhs>>::BinaryExpression;
+};
+
+
+/** An expression representing right scalar multiplication of a vector.
+ */
+template <typename Lhs, typename Rhs>
+struct ScaleR : internal::base_tmpl_t<Lhs, ScaleR<Lhs, Rhs>>,
+                BinaryExpression<ScaleR<Lhs, Rhs>> {
+    // Inherit constructor from BinaryExpression
+    using BinaryExpression<ScaleR<Lhs, Rhs>>::BinaryExpression;
+};
+
+namespace internal {
+
+// Traits for left scalar multiplication
+// Keep the frames of the vector side.
+// @todo add scalar mixing. Currently the type of Rhs is kept.
+template <typename Lhs, typename Rhs>
+struct traits<Scale<Lhs, Rhs>> : binary_traits_base<Scale<Lhs, Rhs>> {
+    using OutputFunctor =
+      WrapWithFrames<LeftFrameOf<Rhs>, MiddleFrameOf<Rhs>, RightFrameOf<Rhs>>;
+};
+
+// Traits for right scalar multiplication
+// Keep the frames of the vector side.
+// @todo add scalar mixing. Currently the type of Lhs is kept.
+template <typename Lhs, typename Rhs>
+struct traits<ScaleR<Lhs, Rhs>> : binary_traits_base<ScaleR<Lhs, Rhs>> {
+    using OutputFunctor =
+      WrapWithFrames<LeftFrameOf<Lhs>, MiddleFrameOf<Lhs>, RightFrameOf<Lhs>>;
+};
+
+}  // namespace internal
+}  // namespace wave
+
+#endif  // WAVE_GEOMETRY_SCALE_HPP

--- a/include/wave/geometry/src/util/macros.hpp
+++ b/include/wave/geometry/src/util/macros.hpp
@@ -76,4 +76,45 @@
         return ExprName<internal::arg_t<R>>{std::move(rhs).derived()}; \
     }
 
+
+/** Generate overloaded binary functions where one side is a plain scalar to be wrapped */
+#define WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_LEFT(OpSymbol, RhsBase)                       \
+    template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<L>{})>           \
+    auto operator OpSymbol(L &&lhs, const RhsBase<R> &rhs)                               \
+      ->decltype(internal::wrapInputScalar(std::forward<L>(lhs))                         \
+                   OpSymbol rhs.derived()) {                                             \
+        return internal::wrapInputScalar(std::forward<L>(lhs)) OpSymbol rhs.derived();   \
+    }                                                                                    \
+                                                                                         \
+    template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<L>{})>           \
+    auto operator OpSymbol(L &&lhs, RhsBase<R> &&rhs)                                    \
+      ->decltype(internal::wrapInputScalar(std::forward<L>(lhs)) OpSymbol std::move(rhs) \
+                   .derived()) {                                                         \
+        return internal::wrapInputScalar(std::forward<L>(lhs)) OpSymbol std::move(rhs)   \
+          .derived();                                                                    \
+    }
+
+/** Generate overloaded binary functions where one side is a plain scalar to be wrapped */
+#define WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_RIGHT(OpSymbol, LhsBase)                    \
+    template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<R>{})>         \
+    auto operator OpSymbol(const LhsBase<L> &lhs, R &&rhs)                             \
+      ->decltype(lhs.derived()                                                         \
+                   OpSymbol internal::wrapInputScalar(std::forward<R>(rhs))) {         \
+        return lhs.derived() OpSymbol internal::wrapInputScalar(std::forward<R>(rhs)); \
+    }                                                                                  \
+                                                                                       \
+    template <typename L, typename R, TICK_REQUIRES(internal::is_scalar<R>{})>         \
+    auto operator OpSymbol(LhsBase<L> &&lhs, R &&rhs)                                  \
+      ->decltype(std::move(lhs).derived()                                              \
+                   OpSymbol internal::wrapInputScalar(std::forward<R>(rhs))) {         \
+        return std::move(lhs).derived()                                                \
+          OpSymbol internal::wrapInputScalar(std::forward<R>(rhs));                    \
+    }
+
+/** Generate overloaded binary functions where one side is a plain scalar to be wrapped
+ * (for scalar on both left and right) */
+#define WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(OpSymbol, LhsBase)  \
+    WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_LEFT(OpSymbol, LhsBase) \
+    WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_RIGHT(OpSymbol, LhsBase)
+
 #endif  // WAVE_GEOMETRY_MACROS_HPP

--- a/include/wave/geometry/src/util/macros.hpp
+++ b/include/wave/geometry/src/util/macros.hpp
@@ -113,8 +113,8 @@
 
 /** Generate overloaded binary functions where one side is a plain scalar to be wrapped
  * (for scalar on both left and right) */
-#define WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(OpSymbol, LhsBase)  \
-    WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_LEFT(OpSymbol, LhsBase) \
-    WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_RIGHT(OpSymbol, LhsBase)
+#define WAVE_OVERLOAD_OPERATORS_FOR_SCALAR(OpSymbol, OtherBase)  \
+    WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_LEFT(OpSymbol, OtherBase) \
+    WAVE_OVERLOAD_OPERATORS_FOR_SCALAR_RIGHT(OpSymbol, OtherBase)
 
 #endif  // WAVE_GEOMETRY_MACROS_HPP

--- a/test/scalar_expression_op_test.cpp
+++ b/test/scalar_expression_op_test.cpp
@@ -39,6 +39,7 @@ TYPED_TEST_CASE(ScalarOpTest, ScalarTypes);
 GENERATE_OP_TESTS(+, add)
 GENERATE_OP_TESTS(-, subtract)
 GENERATE_OP_TESTS(*, multiply)
+GENERATE_OP_TESTS(/, divide)
 
 // These tests handle variations of rvalues in multi-level expressions, and check
 // Jacobians. For the other operators assume rvalues work for now. @todo generate these

--- a/test/scalar_expression_op_test.cpp
+++ b/test/scalar_expression_op_test.cpp
@@ -5,8 +5,44 @@ template <typename ScalarType_>
 class ScalarOpTest : public ScalarTest<ScalarType_> {};
 TYPED_TEST_CASE(ScalarOpTest, ScalarTypes);
 
-// These tests handle variations of rvalues in multi-level expressions
-// For the other operators assume rvalues work for now. @todo generate tests?
+#define GENERATE_OP_TESTS(OP, NAME)                         \
+    TYPED_TEST(ScalarOpTest, NAME) {                        \
+        const auto s1 = wave::Scalar<TypeParam>{this->a()}; \
+        const auto s2 = wave::Scalar<TypeParam>{this->b()}; \
+                                                            \
+        const auto expr = s1 OP s2;                         \
+                                                            \
+        EXPECT_EQ(this->a() OP this->b(), eval(expr));      \
+        CHECK_JACOBIANS(false, s1 OP s2, s1, s2);           \
+    }                                                       \
+                                                            \
+    TYPED_TEST(ScalarOpTest, NAME##ScalarOnLeft) {          \
+        const auto s1 = this->a();                          \
+        const auto s2 = wave::Scalar<TypeParam>{this->b()}; \
+                                                            \
+        const auto expr = s1 OP s2;                         \
+                                                            \
+        EXPECT_EQ(this->a() OP this->b(), eval(expr));      \
+        CHECK_JACOBIANS(true, s1 OP s2, s1, s2);            \
+    }                                                       \
+    TYPED_TEST(ScalarOpTest, NAME##ScalarOnRight) {         \
+        const auto s1 = wave::Scalar<TypeParam>{this->a()}; \
+        const auto s2 = this->b();                          \
+                                                            \
+        const auto expr = s1 OP s2;                         \
+                                                            \
+        EXPECT_EQ(this->a() OP this->b(), eval(expr));      \
+        CHECK_JACOBIANS(true, s1 OP s2, s1, s2);            \
+    }
+
+
+GENERATE_OP_TESTS(+, add)
+GENERATE_OP_TESTS(-, subtract)
+GENERATE_OP_TESTS(*, multiply)
+
+// These tests handle variations of rvalues in multi-level expressions, and check
+// Jacobians. For the other operators assume rvalues work for now. @todo generate these
+// tests also?
 
 TYPED_TEST(ScalarOpTest, addExprToScalarLeft) {
     const auto s1 = this->a();
@@ -68,16 +104,6 @@ TYPED_TEST(ScalarOpTest, addExprToScalarRightRvalue2) {
     const auto expr = wave::Scalar<TypeParam>{this->b()} + this->a();
     EXPECT_EQ(this->b() + this->a(), eval(expr));
     CHECK_JACOBIANS(false, expr, expr.lhs(), expr.rhs());
-}
-
-TYPED_TEST(ScalarOpTest, subtract) {
-    const auto s1 = wave::Scalar<TypeParam>{this->a()};
-    const auto s2 = wave::Scalar<TypeParam>{this->b()};
-
-    const auto result = eval(s1 - s2);
-
-    EXPECT_EQ(this->a() - this->b(), result.value());
-    CHECK_JACOBIANS(false, s1 - s2, s1, s2);
 }
 
 TYPED_TEST(ScalarOpTest, subtractExprFromScalarLeft) {

--- a/test/scalar_expression_test.cpp
+++ b/test/scalar_expression_test.cpp
@@ -66,3 +66,4 @@ TYPED_TEST(ScalarTest, assignFromExpression) {
 
 GENERATE_OP_TEST(+, add)
 GENERATE_OP_TEST(-, subtract)
+GENERATE_OP_TEST(*, multiply)

--- a/test/scalar_expression_test.cpp
+++ b/test/scalar_expression_test.cpp
@@ -52,18 +52,3 @@ TYPED_TEST(ScalarTest, assignFromExpression) {
     s = t.norm();
     EXPECT_EQ(t.value().norm(), s);
 }
-
-#define GENERATE_OP_TEST(OP, NAME)                          \
-    TYPED_TEST(ScalarTest, NAME) {                          \
-        const auto s1 = wave::Scalar<TypeParam>{this->a()}; \
-        const auto s2 = wave::Scalar<TypeParam>{this->b()}; \
-                                                            \
-        const auto expr = s1 OP s2;                         \
-                                                            \
-        EXPECT_EQ(this->a() OP this->b(), eval(expr));      \
-        CHECK_JACOBIANS(false, s1 OP s2, s1, s2);           \
-    }
-
-GENERATE_OP_TEST(+, add)
-GENERATE_OP_TEST(-, subtract)
-GENERATE_OP_TEST(*, multiply)

--- a/test/scalar_expression_test.hpp
+++ b/test/scalar_expression_test.hpp
@@ -26,11 +26,13 @@ class ScalarTest : public testing::Test {
     TICK_TRAIT_CHECK(wave::internal::is_leaf_expression<Leaf>);
     TICK_TRAIT_CHECK(wave::internal::is_unary_expression<wave::ScalarRef<ScalarType>>);
 
-    // Make some random values, different for each test
+    // Make some semi-random values, different for each test
+    // (too big or small can ruin numerical diff accuracy for some functions, e.g. if
+    // dividing by near-zero)
     const ScalarType rand_a =
-      wave::uniformRandom<ScalarType>(ScalarType{-3.0}, ScalarType{3.0});
+      wave::uniformRandom<ScalarType>(ScalarType{0.5}, ScalarType{3.0});
     const ScalarType rand_b =
-      wave::uniformRandom<ScalarType>(ScalarType{-3.0}, ScalarType{3.0});
+      wave::uniformRandom<ScalarType>(ScalarType{0.5}, ScalarType{3.0});
 
     // Return them as rvalues
     ScalarType a() const {


### PR DESCRIPTION
Resolves #5 

Add scalar multiplication, including scalar * scalar and scalar * vector.

New expressions:
 * Scale: scalar * vector
 * ScaleR: vector * scalar
 * ScaleDiv: vector / scalar
 * Product: scalar * scalar
 * Divide: scalar / scalar

It would be possible to combine some of these to save lines of code, but using a distinct `struct` for each adds some clarity to compiler messages.

Add `WAVE_OVERLOAD_OPERATORS_FOR_SCALAR` macro to generate operators taking combinations of built-in scalar and expression types. 

Left to do:
- More careful handling of scalar mixing (currently, the output vector has the same scalar type as the input vector, which is sloppy)