### PR TITLE
Fix derivative wrt rvalue leaf stored in expression

### DIFF
--- a/include/wave/geometry/src/core/forward_declarations.hpp
+++ b/include/wave/geometry/src/core/forward_declarations.hpp
@@ -16,12 +16,9 @@ struct traits;
 template <typename T>
 struct traits<const T> : traits<T> {};
 
-// T&& in expression parameters means store-by-value.
-// These traits have special modifications
+// There are no distinct traits of a && type
 template <typename T>
-struct traits<T &&> : traits<T> {
-    using PreparedType = typename traits<T>::PreparedType &&;
-};
+struct traits<T &&> : traits<T> {};
 
 /** Marker of a missing expression implemenation */
 struct NotImplemented;

--- a/include/wave/geometry/src/core/storage/RefSelector.hpp
+++ b/include/wave/geometry/src/core/storage/RefSelector.hpp
@@ -9,15 +9,21 @@ namespace wave {
 namespace internal {
 /** Helper to choose storage type (reference or value) for expressions.
  *
- * We pass the result of decltype() to this template. T should be a wave_geometry
- * expression.
+ * T should be a wave_geometry expression type.
  *
- * If the input T is an rvalue reference, we want to store it by value.
+ * If the input T is an rvalue reference, we want to store it by value. If T is an lvalue
+ * reference, we store it by lvalue reference.  Otherwise, we want to see whether it
+ * refers to a leaf or to a lightweight expression, and store it by value if the latter
+ * (as in Eigen).
  *
- * Otherwise, we want to see whether it refers to a leaf or
- * to a lightweight expression, and store it by value if the latter (as in Eigen).
+ * | input  | output      |
+ * |--------|-------------|
+ * | Expr   | Expr        |
+ * | Expr&& | Expr        |
+ * | Leaf   | const Leaf& |
+ * | Leaf&& | Leaf        |
  *
- **/
+ */
 template <typename T>
 using wave_ref_sel_t =
   tmp::conditional_t<std::is_rvalue_reference<T>{},

--- a/include/wave/geometry/src/util/macros.hpp
+++ b/include/wave/geometry/src/util/macros.hpp
@@ -8,12 +8,18 @@
 
 #include <Eigen/Core>
 
+#ifdef NDEBUG
 #if EIGEN_COMP_CLANG
 // Based on experiments, always_inline makes clang-4.0 faster, but not GCC
 #define WAVE_STRONG_INLINE EIGEN_ALWAYS_INLINE
 #else
 #define WAVE_STRONG_INLINE EIGEN_STRONG_INLINE
 #endif
+#else
+// When debugging don't force inlining
+#define WAVE_STRONG_INLINE inline
+#endif
+
 
 // We sometimes need to explicitly declare special member functions (copy constructors and
 // operator=) even when they should already be defaulted, to avoid a GCC bug

--- a/test/is_same_test.cpp
+++ b/test/is_same_test.cpp
@@ -63,3 +63,22 @@ TEST(IsSame, complex) {
     auto expr_copy = expr;
     EXPECT_TRUE(wave::isSame(expr, expr_copy));
 }
+
+TEST(IsSame, rvalueCopy) {
+    const auto t1 = wave::Translationd::Random();
+
+    // expr is initialized with an rvalue leaf, thus it stores the leaf
+    // (expr is Minus<Translationd&&>)
+    const auto expr = -(wave::Translationd::Random());
+
+    // expr2 stores a *copy* of expr, including the leaf. Therefore isSame() here is
+    // false, and we can't differentiate expr2 wrt expr.rhs().
+    // @todo The decision about copying expressions with stored leaves may change.
+    const auto expr2 = t1 + expr;
+    EXPECT_TRUE(isSame(t1, expr2.lhs()));
+    EXPECT_FALSE(isSame(expr, expr2.rhs()));
+    EXPECT_FALSE(isSame(expr.rhs(), expr2.rhs().rhs()));
+
+    // Note the stored leaves are equal, though separate copies.
+    EXPECT_EQ(expr.rhs().value(), expr2.rhs().rhs().value());
+}

--- a/test/rvalue_expression_test.cpp
+++ b/test/rvalue_expression_test.cpp
@@ -27,6 +27,9 @@ class RvalueTest : public testing::Test {
 
     using ZeroLeafAAB = wave::Zero<LeafAAB>;
     using ZeroLeafABC = wave::Zero<LeafABC>;
+
+    // Used for CHECK_JACOBIANS macro
+    static constexpr bool IsFramed = Params::IsFramed;
 };
 TYPED_TEST_CASE(RvalueTest, LeafTypes);
 
@@ -54,13 +57,13 @@ TYPED_TEST(RvalueTest, addTemporaryExpr) {
     const auto v2 = typename TestFixture::Vector{TestFixture::Vector::Random()};
 
     // Sum with rvalue
-    const auto expr =
-      typename TestFixture::LeafAAC{t1 + typename TestFixture::LeafABC{v2}};
+    const auto expr = t1 + typename TestFixture::LeafABC{v2};
 
     const auto result = typename TestFixture::LeafAAC{expr};
 
     const auto eigen_result = typename TestFixture::Vector{t1.value() + v2};
     EXPECT_APPROX(eigen_result, result.value());
+    CHECK_JACOBIANS(TestFixture::IsFramed, expr, expr.lhs(), expr.rhs());
 }
 
 TYPED_TEST(RvalueTest, addTemporaryExpr2) {

--- a/test/rvalue_expression_test.cpp
+++ b/test/rvalue_expression_test.cpp
@@ -2,7 +2,7 @@
 #include "test.hpp"
 
 /** The list of implementation types to run each test case on */
-using LeafTypes = testing::Types<UnframedParams<wave::Translationd>>;
+using LeafTypes = test_types_list<wave::Translationd>;
 
 template <typename Params>
 class RvalueTest : public testing::Test {
@@ -24,6 +24,7 @@ class RvalueTest : public testing::Test {
     using LeafABA = Framed<Leaf, FrameA, FrameB, FrameA>;
     using LeafACA = Framed<Leaf, FrameA, FrameC, FrameA>;
     using LeafAAC = Framed<Leaf, FrameA, FrameA, FrameC>;
+    using LeafACB = Framed<Leaf, FrameA, FrameC, FrameB>;
 
     using ZeroLeafAAB = wave::Zero<LeafAAB>;
     using ZeroLeafABC = wave::Zero<LeafABC>;
@@ -72,15 +73,29 @@ TYPED_TEST(RvalueTest, addTemporaryExpr2) {
     const auto v3 = typename TestFixture::Vector{TestFixture::Vector::Random()};
 
     // Subtraction with rvalue
-    const auto expr = t1 - typename TestFixture::LeafABC{v2};
+    const auto expr = t1 - typename TestFixture::LeafACB{v2};
 
     // Minus with rvalue
-    const auto expr2 = expr + -(typename TestFixture::LeafACA{v3});
+    const auto expr2 = expr + -(typename TestFixture::LeafAAC{v3});
 
     const auto result = typename TestFixture::LeafAAA{expr2};
 
     const auto eigen_result = typename TestFixture::Vector{t1.value() - v2 - v3};
     EXPECT_APPROX(eigen_result, result.value());
+
+    // Note the user would need to know the leaf is at rhs().rhs() because - is it's own
+    // unary expression. This kind of Jacobian evaluation is not expected from the user,
+    // but we should make sure it works anyways.
+    CHECK_JACOBIANS(TestFixture::IsFramed, expr, expr.lhs(), expr.rhs().rhs());
+    CHECK_JACOBIANS(TestFixture::IsFramed,
+                    expr2,
+                    expr2.lhs().lhs(),
+                    expr2.lhs().rhs().rhs(),
+                    expr2.rhs().rhs());
+
+    // Note that we *can't* currently differentiate expr2 wrt a leaf in expr1
+    // This is because initializing `expr2 = expr + ...` *copies* expr into expr2
+    // including any stored leaves. See the test `rvalueCopy` in is_same_test.
 }
 
 TYPED_TEST(RvalueTest, negateWithFrameCast) {


### PR DESCRIPTION
- Fix taking Jacobian with rvalue expressions
  When running PrepareExpr on an expression containing a leaf by value (denoted `Expr<Leaf&&>`), *don't* copy the Leaf&& to PreparedType.  Instead, the "prepared" expression contains an lvalue reference to the leaf in the original expression (`Expr<Leaf>`). This change allows applying isSame() between the prepared and original expression.

  See the updated test.

  Drawback: the prepared expression can no longer exist outside of the original expression's lifetime. Currently this is not a problem, but something to be careful about in the future.

- Expand rvalue test
  Add description of how currently, using an expression in another expression *copies* it, including any stored leaves.

- Don't force inline in Debug build