### PR TITLE
Fix clang 5 warning

### DIFF
--- a/include/wave/geometry/src/geometry/frames/Framed.hpp
+++ b/include/wave/geometry/src/geometry/frames/Framed.hpp
@@ -44,9 +44,6 @@ class Framed : public internal::base_tmpl_t<WrappedLeaf, Framed<WrappedLeaf, Fra
                          internal::is_vector_leaf<WrappedLeaf>{} &&
                          typename tmp::conjunction<std::is_arithmetic<Args>...>{}>;
 
-    // Workaround for clang 3 bug. `Framed` must be treated as a template here
-    using Tag = internal::expr<Framed::template Framed>;
-
     using Scalar = internal::scalar_t<WrappedLeaf>;
 
  private:
@@ -124,6 +121,8 @@ class Framed : public internal::base_tmpl_t<WrappedLeaf, Framed<WrappedLeaf, Fra
     friend struct internal::FramedLeafAccessBase<Framed>;
 
     // Strip frames at the start of evaluation
+    // Note these friend functions are free functions which will be found by ADL.
+    using Tag = typename internal::traits<Framed>::Tag;
     friend auto evalImpl(Tag, const Framed &f) -> const WrappedLeaf & {
         return f.wrapped_leaf;
     }


### PR DESCRIPTION
In this case we wanted `Framed` to refer to the class template. Clang 3 wrongly treated it as a type-name. When changed to `Framed::template Framed`, Clang 5 warned that that actually means a constructor. An alternative solution is to qualify the name (`::wave::Framed`).

Here, avoid the whole issue by reusing the existing `Tag` alias in `traits`.