### PR TITLE
Fix compile error in some jacobian calls

### DIFF
--- a/include/wave/geometry/src/core/functions/TypedJacobianEvaluator.hpp
+++ b/include/wave/geometry/src/core/functions/TypedJacobianEvaluator.hpp
@@ -262,7 +262,9 @@ auto evaluateTypedJacobian(const ExpressionBase<Derived> &expr,
     // Note since we don't return the value, we don't need the user-facing OutputType
     using OutType = eval_output_t<Derived>;
     const auto &v_eval = prepareEvaluatorTo<OutType>(expr.derived());
-    internal::TypedJacobianEvaluator<Derived, TargetDerived> j_eval{v_eval, target};
+    using ExprType = tmp::remove_cr_t<decltype(v_eval.expr)>;
+
+    internal::TypedJacobianEvaluator<ExprType, TargetDerived> j_eval{v_eval, target};
     const auto &result = j_eval.jacobian();
     return result;
 }

--- a/test/rotation_test.cpp
+++ b/test/rotation_test.cpp
@@ -144,7 +144,10 @@ TYPED_TEST_P(RotationTest, rotateVectorByInverse) {
     // As in other tests, CHECK_JACOBIANS checks all Jacobian evaluators, but some
     // high-level glue code that constructs the evaluators isn't checked by that macro.
     // Check it here for a few cases.
-    const auto [p2, J_p2_wrt_r1, J_p2_wrt_p1] = expr.evalWithJacobians(r1, p1);
+    typename TestFixture::PointBAB p2;  // gcc-6 support
+                                        // @todo gcc-7: update to structured binding
+    typename TestFixture::Matrix3 J_p2_wrt_r1, J_p2_wrt_p1;
+    std::tie(p2, J_p2_wrt_r1, J_p2_wrt_p1) = expr.evalWithJacobians(r1, p1);
     const auto J_p2_wrt_r1_single = expr.jacobian(r1);
     const auto J_p2_wrt_p1_single = expr.jacobian(p1);
 


### PR DESCRIPTION
Fix #11

A "no matching constructor" error happened for a class of expressions when the jacobian was requested via expr.jacobian(x), but not expr.evalWithJacobians(x). The cause was incorrect template arguments used to instantiate the jacobian evaluator.

Use correct and consistent evaluator type.  Add a test which catches the issue.